### PR TITLE
fix: Update Issue Templates to be Selectable on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,3 @@
-# Bug Report
-=======
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,3 @@
-
-# Feature Request
-=======
 ---
 name: Feature request
 about: Suggest an idea for this project


### PR DESCRIPTION
Issue templates are currently not selectable. Now it should be a popup when you go to make a new issue you can select from the choices. 

2. List the names of those who contributed to the project.
@PCain02

3. Link the issue the pull request is meant to fix/resolve.
https://github.com/GatorEducator/execexam/issues/44

4. Describe the contents and goal of the pull request.
This PR adds the ability to select an issue template when going to make an issue. The choices are bug, feature, or custom.

5. What operating systems has this been tested on? How were these tests conducted?

This is a feature on GitHub so it does not really apply but I am on Windows 10

7. Add all labels that apply. (e.g., documentation, ready-for-review)
Infrastructure

8. Will coverge be maintained/increased?
This does not affect coverage.

9. Include a code block and/or screenshots displaying the functionality of your
feature, if applicable/possible.