### PR TITLE
feat: produce output when commands/checks are executed

### DIFF
--- a/execexam/main.py
+++ b/execexam/main.py
@@ -65,7 +65,7 @@ def run(  # noqa: PLR0913, PLR0915
     ] = None,
     report: Optional[List[enumerations.ReportType]] = typer.Option(
         [enumerations.ReportType.exitcode],  # set the exitcode as default
-        help="Types of reports to generate. Status (exitcode) is shown by default",
+        help="Types of reports to generate.",
     ),
     mark: str = typer.Option(None, help="Run tests with specified mark(s)"),
     maxfail: int = typer.Option(

--- a/execexam/main.py
+++ b/execexam/main.py
@@ -64,8 +64,8 @@ def run(  # noqa: PLR0913, PLR0915
         ),
     ] = None,
     report: Optional[List[enumerations.ReportType]] = typer.Option(
-        None,
-        help="Types of reports to generate",
+        [enumerations.ReportType.exitcode],  # set the exitcode as default
+        help="Types of reports to generate. Status (exitcode) is shown by default",
     ),
     mark: str = typer.Option(None, help="Run tests with specified mark(s)"),
     maxfail: int = typer.Option(


### PR DESCRIPTION
# Produce Output When Executed

1. Modifying `execexam` to produce an output when executed.

2. @hemanialaparthi 

3. #42 

4. `bug`, `enhancement`, `ready for review`

5. The goal of this pull request is to ensure that `execexam` provides meaningful output when it encounters a failure. Currently, the lack of output can mislead users into believing the program executed successfully, as silence is often interpreted as success.

6. Coverage will be maintained as this update includes error handling tests to verify the new functionality.

7. Tested on macOS

8. Include a code block and/or screenshots displaying the functionality of your feature, if applicable/possible.