### PR TITLE
fix: removed coverage.json file, updated version and coverage badge to work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,17 @@ jobs:
         run: |
           poetry run task test-not-fuzz
       # Run the tests and coverage
-      - name: Run Tests and Generate Coverage
-        run: |
-          poetry run pytest -s --cov=my_package --cov-report json:coverage.json
+      - name: Run Tests and Update Badges
+        run: poetry run python scripts/badges.py
       # Generate badges
       - name: Generate Coverage and Version Badges
         run: |
           poetry run python scripts/badges.py
+      - name: Commit updated README.md
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add README.md
+          git commit -m "Update badges in README.md" || echo "No changes to commit"
+          git push
+  

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="https://i.ibb.co/vzjX7p2/exe.png" alt="logo" height="500">
 
-[![coverage](https://img.shields.io/badge/coverage-20.86%25-brightgreen)](https://github.com/GatorEducator/execexam/actions)
+[![coverage](https://img.shields.io/badge/coverage-83.00%25-brightgreen?cacheBust=1732220727.141896)](https://github.com/GatorEducator/execexam/actions)
 [![Static Badge](https://img.shields.io/badge/Maintained%3F-yes-orange)](https://github.com/GatorEducator/execexam/commits/main/)
-![version](https://img.shields.io/badge/version-0.3.0-blue)
+![version](https://img.shields.io/badge/version-0.3.3-blue?cacheBust=1732220727.142039)
 
 
 ExecExam is a powerful tool that runs executable examinations in which a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "execexam"
-version = "0.3.2"
+version = "0.3.3"
 description = "ExecExam runs executable examinations, providing feedback and assistance!"
 authors = ["Hemani Alaparthi <alaparthi01@allegheny.edu>","Gregory M. Kapfhammer <gkapfham@allegheny.edu>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request

Contributors:
@Chezka109 

Issue Addressed:
This pull request addresses and resolves Issue #51.

Labels:
Enhancement

Goal of This Pull Request:
This PR introduces updates and fixes to the badge system. The coverage badge is updated to now need a .json file anymore, the version badge is now correct.

Testing:
Operating Systems Tested On: MacOS

Screenshots:
`build.yml`
<img width="613" alt="Screenshot 2024-11-21 at 3 32 54 PM" src="https://github.com/user-attachments/assets/7dec5d47-d4de-45f4-89ea-0b53e7e04a42">
This runs the commands in GitHub actions to update the badges automatically using the workflow.

`pytest --cov=. --cov-report=term`
<img width="1521" alt="Screenshot 2024-11-21 at 3 34 17 PM" src="https://github.com/user-attachments/assets/ea1852b0-ade9-41ae-8c40-5fa9b611a61f">

Will run coverage and will collect data depending on the `TOTAL` percentage.

`python scripts/badges.py`
When this command is run, either manually or through the CI/CD pipeline, it will output either an `ERROR` or `SUCCESS` message for both the coverage and version badges.
<img width="204" alt="Screenshot 2024-11-21 at 3 35 16 PM" src="https://github.com/user-attachments/assets/cc35e0dd-83e1-44f3-a629-0de7c538a6e4">
Codeblock for outputs (through regex):
```py
        match = re.search(r"TOTAL\s+\d+\s+\d+\s+(\d+)%", result.stdout)
        if match:
            return float(match.group(1))
        else:
            print(
                "[ERROR] Could not extract coverage percentage from pytest output."
            )
            return None
    except subprocess.CalledProcessError as e:
        print(f"[ERROR] pytest failed: {e.stderr}")
        return None


def get_version():
    """Fetch version from pyproject.toml."""
    if not os.path.exists(PYPROJECT_FILE):
        print(f"[ERROR] {PYPROJECT_FILE} not found.")
        return None
    try:
        with open(PYPROJECT_FILE) as f:
            pyproject_data = toml.load(f)
            return pyproject_data["tool"]["poetry"]["version"]
    except (KeyError, toml.TomlDecodeError) as e:
        print(f"[ERROR] Invalid format in {PYPROJECT_FILE}: {e}")
        return None
```